### PR TITLE
fix(django 4.1): Restrict sql_create_sequence to < django 4.1

### DIFF
--- a/django_zero_downtime_migrations/backends/postgres/schema.py
+++ b/django_zero_downtime_migrations/backends/postgres/schema.py
@@ -150,7 +150,8 @@ class DatabaseSchemaEditorMixin:
     sql_set_lock_timeout = "SET lock_timeout TO '%(lock_timeout)s'"
     sql_set_statement_timeout = "SET statement_timeout TO '%(statement_timeout)s'"
 
-    sql_create_sequence = PGAccessExclusive(PostgresDatabaseSchemaEditor.sql_create_sequence, use_timeouts=False)
+    if django.VERSION[:2] < (4, 1):
+        sql_create_sequence = PGAccessExclusive(PostgresDatabaseSchemaEditor.sql_create_sequence, use_timeouts=False)
     sql_delete_sequence = PGAccessExclusive(PostgresDatabaseSchemaEditor.sql_delete_sequence, use_timeouts=False)
     sql_create_table = PGAccessExclusive(PostgresDatabaseSchemaEditor.sql_create_table, use_timeouts=False)
     sql_delete_table = PGAccessExclusive(PostgresDatabaseSchemaEditor.sql_delete_table, use_timeouts=False)


### PR DESCRIPTION
Fixes #38

Note: Doesn't necessarily add support `sql_add_identity` and `sql_drop_identity` - That may be better to do in a separate PR / issue, I'm not sure how to handle it.

See also: https://github.com/django/django/commit/2eea361eff58dd98c409c5227064b901f41bd0d6