### PR TITLE
fix deferred sql errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # django-pg-zero-downtime-migrations changelog
 
 ## 0.14
+  - fix deferred sql errors
   - drop postgres 11 support
   - mark `migrate_isnotnull_check_constraints` command deprecated
 

--- a/tests/apps/good_flow_app/migrations/0004_set_field_not_null.py
+++ b/tests/apps/good_flow_app/migrations/0004_set_field_not_null.py
@@ -3,6 +3,11 @@
 from django.db import IntegrityError, migrations, models
 
 
+def flush_deferred_sql(apps, schema_editor):
+    for sql in schema_editor.deferred_sql:
+        schema_editor.execute(sql)
+
+
 def update_objects(apps, schema_editor):
     db_alias = schema_editor.connection.alias
     TestTable = apps.get_model('good_flow_app', 'TestTable')
@@ -37,5 +42,6 @@ class Migration(migrations.Migration):
             name='field',
             field=models.IntegerField(default=0),
         ),
+        migrations.RunPython(flush_deferred_sql, migrations.RunPython.noop),
         migrations.RunPython(insert_objects_and_not_null_check, migrations.RunPython.noop),
     ]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -51,6 +51,15 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+MIGRATION_MODULES = {
+    'admin': None,
+    'auth': None,
+    'contenttypes': None,
+    'sessions': None,
+    'messages': None,
+    'staticfiles': None,
+}
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
Fix for https://github.com/tbicr/django-pg-zero-downtime-migrations/issues/48

Internally django runs sql immediately or deferredly.

This lib rewrite standard sql and split some complex sql to two parts one of them go to immediate execution and second go to deferred execution. For example creation not null fields and unique constraints that require `SHARE UPDATE EXCLUSIVE` lock sql (deferred) that cannot to run together with `ACCESS EXCLUSIVE` lock sql (immediate) be *safe*.

As mostly constraints created deferred way it looks safe to preserve default django approach. However nice to keep option to switch approaches for a while.