### PR TITLE
fix django 3.2 degradation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # django-pg-zero-downtime-migrations changelog
 
+## 0.15
+  - fixed django 3.2 degradation with missing `skip_default_on_alter` method
+
 ## 0.14
   - fixed deferred sql errors
   - added django 5.0 support

--- a/django_zero_downtime_migrations/backends/postgres/schema.py
+++ b/django_zero_downtime_migrations/backends/postgres/schema.py
@@ -432,6 +432,14 @@ class DatabaseSchemaEditorMixin:
             self.deferred_sql.append(self._create_unique_sql(model, [field.column]))
         return ""
 
+    if django.VERSION[:2] <= (3, 2):
+        def skip_default_on_alter(self, field):
+            """
+            Some backends don't accept default values for certain columns types
+            (i.e. MySQL longtext and longblob) in the ALTER COLUMN statement.
+            """
+            return False
+
     def column_sql(self, model, field, include_default=False):
         """
         Take a field and return its column definition.


### PR DESCRIPTION
fix for https://github.com/tbicr/django-pg-zero-downtime-migrations/issues/56

`skip_default_on_alter` were introduced in django 4.0 and django_zero_downtime_migrations code were migrated to it, but it brings issue to django 3.2, so this MR back `skip_default_on_alter` to django 3.2