### PR TITLE
fix sqlmigrate with idempotent mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
   - changed `ADD COLUMN DEFAULT NULL` to safe operation for code default
   - changed `ADD COLUMN DEFAULT NOT NULL` to safe operation for `db_default` in django 5.0+
   - added `ZERO_DOWNTIME_MIGRATIONS_KEEP_DEFAULT` settings and changed `ADD COLUMN DEFAULT NOT NULL` with this settings to safe operation for django<5.0
+  - fixed sqlmigrate in idempotent mode
   - updated unsafe migrations links to documentation
   - updated patched code to latest django version
   - improved README

--- a/django_zero_downtime_migrations/backends/postgres/schema.py
+++ b/django_zero_downtime_migrations/backends/postgres/schema.py
@@ -495,7 +495,11 @@ class DatabaseSchemaEditorMixin:
             settings, "ZERO_DOWNTIME_MIGRATIONS_FLEXIBLE_STATEMENT_TIMEOUT", False)
         self.RAISE_FOR_UNSAFE = getattr(settings, "ZERO_DOWNTIME_MIGRATIONS_RAISE_FOR_UNSAFE", False)
         self.DEFERRED_SQL = getattr(settings, "ZERO_DOWNTIME_MIGRATIONS_DEFERRED_SQL", True)
-        self.IDEMPOTENT_SQL = getattr(settings, "ZERO_DOWNTIME_MIGRATIONS_IDEMPOTENT_SQL", False)
+        self.IDEMPOTENT_SQL = (
+            getattr(settings, "ZERO_DOWNTIME_MIGRATIONS_IDEMPOTENT_SQL", False)
+            if not collect_sql else
+            False  # disable idempotent mode for sqlmigrate
+        )
         self.KEEP_DEFAULT = getattr(settings, "ZERO_DOWNTIME_MIGRATIONS_KEEP_DEFAULT", False)
         if django.VERSION[:2] >= (5, 0) and hasattr(settings, 'ZERO_DOWNTIME_MIGRATIONS_KEEP_DEFAULT'):
             warnings.warn(


### PR DESCRIPTION
when run sqlmigrate with idempotent mode, lib try to run indempotent condition that can fail as no real object can be presented, as idempotent mode has no sense for sqlmigrate we can just disable it for this case