### PR TITLE
Split and parralelize CI jobs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,10 +8,24 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
-      - name: build image
-        run: docker compose build
-      - name: push image
-        run: docker compose push
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/django-pg-zero-downtime-migrations:latest
 
   check:
     needs:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,5 +19,9 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+      - name: build and pull images
+        run: |
+          docker compose build
+          docker compose pull --quiet
       - name: run checks
         run: docker compose run --rm django-pg-zero-downtime-migrations-tests tox -f ${{ matrix.tox-filter }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,10 +4,20 @@ on: [push, pull_request]
 
 jobs:
   check:
-    name: run checks
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-filter:
+          - "py3.8"
+          - "py3.9"
+          - "py3.10"
+          - "py3.11"
+          - "py3.12"
+          - "py3.13"
+    name: run checks ${{ matrix.tox-filter }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
         uses: actions/checkout@v2
       - name: run checks
-        run: docker compose run --rm django-pg-zero-downtime-migrations-tests tox
+        run: docker compose run --rm django-pg-zero-downtime-migrations-tests tox -f ${{ matrix.tox-filter }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,19 @@ name: Check
 on: [push, pull_request]
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: build image
+        run: docker compose build
+      - name: push image
+        run: docker compose push
+
   check:
+    needs:
+      - build
     strategy:
       fail-fast: false
       matrix:
@@ -19,9 +31,7 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
-      - name: build and pull images
-        run: |
-          docker compose build
-          docker compose pull --quiet
+      - name: pull images
+        run: docker compose pull --quiet
       - name: run checks
         run: docker compose run --rm django-pg-zero-downtime-migrations-tests tox -f ${{ matrix.tox-filter }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,20 +9,22 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          tags: django-pg-zero-downtime-migrations:latest
-          outputs: type=docker,dest=${{ runner.temp }}/main-image.tar
-
-      - name: Upload image as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: main-image
-          path: ${{ runner.temp }}/main-image.tar
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/django-pg-zero-downtime-migrations:latest
 
   check:
     needs:
@@ -42,20 +44,7 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
-
-      - name: Download built image
-        uses: actions/download-artifact@v4
-        with:
-          name: main-image
-          path: ${{ runner.temp }}
-
-      - name: Load image
-        run: |
-          docker load --input ${{ runner.temp }}/main-image.tar
-          docker image ls -a
-
-      - name: Pull DB images
-        run: docker compose pull --quiet --policy missing
-
+      - name: pull images
+        run: docker compose pull --quiet
       - name: run checks
         run: docker compose run --rm django-pg-zero-downtime-migrations-tests tox -f ${{ matrix.tox-filter }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
           tags: django-pg-zero-downtime-migrations:latest
           outputs: type=docker,dest=${{ runner.temp }}/main-image.tar
 
-      - name: Upload artifact
+      - name: Upload image as artifact
         uses: actions/upload-artifact@v4
         with:
           name: main-image
@@ -43,7 +43,7 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
 
-      - name: Download artifact
+      - name: Download built image
         uses: actions/download-artifact@v4
         with:
           name: main-image
@@ -55,7 +55,7 @@ jobs:
           docker image ls -a
 
       - name: Pull DB images
-        run: docker compose pull --quiet
+        run: docker compose pull --quiet --policy missing
 
       - name: run checks
         run: docker compose run --rm django-pg-zero-downtime-migrations-tests tox -f ${{ matrix.tox-filter }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,23 +9,20 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/django-pg-zero-downtime-migrations:latest
+          tags: django-pg-zero-downtime-migrations:latest
+          outputs: type=docker,dest=${{ runner.temp }}/main-image.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-image
+          path: ${{ runner.temp }}/main-image.tar
 
   check:
     needs:
@@ -45,7 +42,20 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
-      - name: pull images
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: main-image
+          path: ${{ runner.temp }}
+
+      - name: Load image
+        run: |
+          docker load --input ${{ runner.temp }}/main-image.tar
+          docker image ls -a
+
+      - name: Pull DB images
         run: docker compose pull --quiet
+
       - name: run checks
         run: docker compose run --rm django-pg-zero-downtime-migrations-tests tox -f ${{ matrix.tox-filter }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - ./docker_postgres_init.sql:/docker-entrypoint-initdb.d/docker_postgres_init.sql
 
   django-pg-zero-downtime-migrations-tests:
-    image: ghcr.io/browniebroke/django-pg-zero-downtime-migrations:latest
+    image: django-pg-zero-downtime-migrations:latest
     build: .
     depends_on:
       - pg17

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,11 @@ services:
 
   django-pg-zero-downtime-migrations-tests:
     image: ghcr.io/browniebroke/django-pg-zero-downtime-migrations:latest
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+      cache_from:
+        - ghcr.io/browniebroke/django-pg-zero-downtime-migrations:latest
     depends_on:
       - pg17
       - pg16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,11 +65,7 @@ services:
 
   django-pg-zero-downtime-migrations-tests:
     image: ghcr.io/browniebroke/django-pg-zero-downtime-migrations:latest
-    build:
-      context: .
-      dockerfile: Dockerfile
-      cache_from:
-        - ghcr.io/browniebroke/django-pg-zero-downtime-migrations:latest
+    build: .
     depends_on:
       - pg17
       - pg16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - ./docker_postgres_init.sql:/docker-entrypoint-initdb.d/docker_postgres_init.sql
 
   django-pg-zero-downtime-migrations-tests:
+    image: ghcr.io/browniebroke/django-pg-zero-downtime-migrations:latest
     build: .
     depends_on:
       - pg17

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - ./docker_postgres_init.sql:/docker-entrypoint-initdb.d/docker_postgres_init.sql
 
   django-pg-zero-downtime-migrations-tests:
-    image: django-pg-zero-downtime-migrations:latest
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER:-tbicr}/django-pg-zero-downtime-migrations:latest
     build: .
     depends_on:
       - pg17


### PR DESCRIPTION
While contributing to this project recently, I struggled a bit to read through CI failures: the logs were super long and noisy, mixing the build and test phases. This was made worse because all jobs were mixed together. 

We can split the build and run to make this a bit easier to read, as well as running each Python version on a separate CI job. The main drawback I see is that the build is duplicated on each job, which isn't optimial, but it's a small one compared to the maintainability gains.

I appreciate that you may feel differently and would understand if you decline this change.