### PR TITLE
Parallelize CI over one job per Python version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,9 +48,8 @@ jobs:
           docker load --input ${{ runner.temp }}/myimage.tar
           docker image ls -a
 
-      - name: build
-        run: docker compose build
-      - name: pull
+      - name: pull DB images
         run: docker compose pull --quiet
+
       - name: run checks
         run: docker compose run --rm django-pg-zero-downtime-migrations-tests tox

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,43 +6,40 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout code
+      - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: set up Docker buildX
-        uses: docker/setup-buildx-action@v1
+      - name: Set up Docker buildX
+        uses: docker/setup-buildx-action@v3
 
       - name: build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
-          context: .
-          file: ./Dockerfile
           tags: django-pg-zero-downtime-migrations:latest
-          outputs: type=docker,dest=/tmp/myimage.tar
+          outputs: type=docker,dest=${{ runner.temp }}/myimage.tar
 
-      - name: upload artifact
-        uses: actions/upload-artifact@v2
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
           name: myimage
-          path: /tmp/myimage.tar
+          path: ${{ runner.temp }}/myimage.tar
 
   check:
-    needs:
-      - build
     name: run checks
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
         uses: actions/checkout@v2
 
-      - name: set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: download artifact
-        uses: actions/download-artifact@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v4
         with:
           name: myimage
-          path: /tmp
+          path: ${{ runner.temp }}
 
       - name: Load Docker image
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,7 +49,7 @@ jobs:
           docker image ls -a
 
       - name: pull DB images
-        run: docker compose pull --quiet
+        run: docker compose pull --quiet --ignore-buildable
 
       - name: run checks
         run: docker compose run --rm django-pg-zero-downtime-migrations-tests tox

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,8 +27,18 @@ jobs:
           path: ${{ runner.temp }}/myimage.tar
 
   check:
-    name: run checks
     needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-filter:
+          - "py3.8"
+          - "py3.9"
+          - "py3.10"
+          - "py3.11"
+          - "py3.12"
+          - "py3.13"
+    name: run checks ${{ matrix.tox-filter }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
@@ -52,4 +62,4 @@ jobs:
         run: docker compose pull --quiet --ignore-buildable
 
       - name: run checks
-        run: docker compose run --rm django-pg-zero-downtime-migrations-tests tox
+        run: docker compose run --rm django-pg-zero-downtime-migrations-tests tox -f ${{ matrix.tox-filter }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Docker buildX
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: build and push
@@ -17,6 +17,8 @@ jobs:
         with:
           tags: django-pg-zero-downtime-migrations:latest
           outputs: type=docker,dest=${{ runner.temp }}/myimage.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -43,7 +45,7 @@ jobs:
 
       - name: Load Docker image
         run: |
-          docker load --input /tmp/myimage.tar
+          docker load --input ${{ runner.temp }}/myimage.tar
           docker image ls -a
 
       - name: build

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,15 +16,15 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           tags: django-pg-zero-downtime-migrations:latest
-          outputs: type=docker,dest=${{ runner.temp }}/myimage.tar
+          outputs: type=docker,dest=${{ runner.temp }}/django-pg-zero-downtime-migrations-image.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: myimage
-          path: ${{ runner.temp }}/myimage.tar
+          name: django-pg-zero-downtime-migrations-image
+          path: ${{ runner.temp }}/django-pg-zero-downtime-migrations-image.tar
 
   check:
     needs: build
@@ -50,12 +50,12 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: myimage
+          name: django-pg-zero-downtime-migrations-image
           path: ${{ runner.temp }}
 
       - name: Load Docker image
         run: |
-          docker load --input ${{ runner.temp }}/myimage.tar
+          docker load --input ${{ runner.temp }}/django-pg-zero-downtime-migrations-image.tar
           docker image ls -a
 
       - name: pull DB images

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,12 +3,52 @@ name: Check
 on: [push, pull_request]
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: set up Docker buildX
+        uses: docker/setup-buildx-action@v1
+
+      - name: build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: django-pg-zero-downtime-migrations:latest
+          outputs: type=docker,dest=/tmp/myimage.tar
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: myimage
+          path: /tmp/myimage.tar
+
   check:
+    needs:
+      - build
     name: run checks
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+
+      - name: set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: myimage
+          path: /tmp
+
+      - name: Load Docker image
+        run: |
+          docker load --input /tmp/myimage.tar
+          docker image ls -a
+
       - name: build
         run: docker compose build
       - name: pull

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # django-pg-zero-downtime-migrations Changelog
 
+## 0.19 (Unreleased)
+- parallelize CI to run one job per Python version
+
 ## 0.18
 - fixed unique constraint creation with the `deferrable` parameter
 - split CI into smaller jobs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 ubuntu:24.04
 
 ENV LC_ALL=C.UTF-8
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - ./docker_postgres_init.sql:/docker-entrypoint-initdb.d/docker_postgres_init.sql
 
   django-pg-zero-downtime-migrations-tests:
+    image: django-pg-zero-downtime-migrations:latest
     build: .
     depends_on:
       - pg17


### PR DESCRIPTION
Took another stab at https://github.com/tbicr/django-pg-zero-downtime-migrations/pull/74 to try get it closer to what we were trying to achieve last time.