### PR TITLE
Add Django 5.2 to the CI and declare support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 0.19 (Unreleased)
 - parallelize CI to run one job per Python version
+- added support for Django 5.2
 
 ## 0.18
 - fixed unique constraint creation with the `deferrable` parameter

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
         'Framework :: Django :: 5.1',
+        'Framework :: Django :: 5.2',
     ],
     keywords='django postgres postgresql migrations',
     packages=find_packages(exclude=['manage*', 'tests*']),

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{3.10,3.11,3.12,3.13}-django{5.1}-psycopg{2,3}
+    py{3.10,3.11,3.12,3.13}-django{5.1,5.2}-psycopg{2,3}
     py{3.10,3.11,3.12}-django{5.0}-psycopg{2,3}
     py{3.8,3.9,3.10,3.11,3.12}-django{4.2}-psycopg{2,3}
 
@@ -9,25 +9,25 @@ usedevelop = True
 allowlist_externals = bash
 commands =
     # linters
-    py{3.13}-django{5.1}-psycopg{3}: flake8
-    py{3.13}-django{5.1}-psycopg{3}: isort . --check --diff
+    py{3.13}-django{5.2}-psycopg{3}: flake8
+    py{3.13}-django{5.2}-psycopg{3}: isort . --check --diff
 
     # unit tests
-    py{3.8,3.9,3.10,3.11,3.12,3.13}-django{4.2,5.0,5.1}-psycopg{2,3}: bash -c "DB_HOST=pg17 DB_USER=test pytest tests/unit"
-    py{3.8,3.9,3.10,3.11,3.12,3.13}-django{4.2,5.0,5.1}-psycopg{2,3}: bash -c "DB_HOST=postgis17 DB_USER=root DB_ENGINE=django_zero_downtime_migrations.backends.postgis pytest tests/unit"
+    py{3.8,3.9,3.10,3.11,3.12,3.13}-django{4.2,5.0,5.1,5.2}-psycopg{2,3}: bash -c "DB_HOST=pg17 DB_USER=test pytest tests/unit"
+    py{3.8,3.9,3.10,3.11,3.12,3.13}-django{4.2,5.0,5.1,5.2}-psycopg{2,3}: bash -c "DB_HOST=postgis17 DB_USER=root DB_ENGINE=django_zero_downtime_migrations.backends.postgis pytest tests/unit"
 
     # integration tests
-    py{3.13}-django{5.1}-psycopg{3}: bash -c "DB_HOST=pg17 DB_USER=test DB_ENGINE=django.db.backends.postgresql pytest tests/integration"
-    py{3.13}-django{5.1}-psycopg{3}: bash -c "DB_HOST=pg17 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
-    py{3.13}-django{5.1}-psycopg{3}: bash -c "DB_HOST=postgis17 DB_USER=root DB_ENGINE=django_zero_downtime_migrations.backends.postgis pytest tests/integration"
+    py{3.13}-django{5.2}-psycopg{3}: bash -c "DB_HOST=pg17 DB_USER=test DB_ENGINE=django.db.backends.postgresql pytest tests/integration"
+    py{3.13}-django{5.2}-psycopg{3}: bash -c "DB_HOST=pg17 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
+    py{3.13}-django{5.2}-psycopg{3}: bash -c "DB_HOST=postgis17 DB_USER=root DB_ENGINE=django_zero_downtime_migrations.backends.postgis pytest tests/integration"
 
     # old psycopg version support integration tests
-    py{3.13}-django{5.1}-psycopg{2}: bash -c "DB_HOST=pg17 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
+    py{3.13}-django{5.2}-psycopg{2}: bash -c "DB_HOST=pg17 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
 
     # old postgres version support integration tests
-    py{3.13}-django{5.1}-psycopg{3}: bash -c "DB_HOST=pg16 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
-    py{3.13}-django{5.1}-psycopg{3}: bash -c "DB_HOST=pg15 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
-    py{3.13}-django{5.1}-psycopg{3}: bash -c "DB_HOST=pg14 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
+    py{3.13}-django{5.2}-psycopg{3}: bash -c "DB_HOST=pg16 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
+    py{3.13}-django{5.2}-psycopg{3}: bash -c "DB_HOST=pg15 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
+    py{3.13}-django{5.2}-psycopg{3}: bash -c "DB_HOST=pg14 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
     py{3.13}-django{5.1}-psycopg{3}: bash -c "DB_HOST=pg13 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
     py{3.12}-django{5.0}-psycopg{3}: bash -c "DB_HOST=pg12 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
 
@@ -36,8 +36,8 @@ commands =
     py{3.12}-django{4.2}-psycopg{3}: bash -c "DB_HOST=pg17 DB_USER=test DB_SUPER_USER=root pytest tests/integration"
 
 deps =
-    py{3.13}-django{5.1}-psycopg{3}: flake8
-    py{3.13}-django{5.1}-psycopg{3}: isort
+    py{3.13}-django{5.2}-psycopg{3}: flake8
+    py{3.13}-django{5.2}-psycopg{3}: isort
 
     pytest
     pytest-django
@@ -49,3 +49,4 @@ deps =
     django4.2: django>=4.2,<5.0
     django5.0: django>=5.0,<5.1
     django5.1: django>=5.1,<5.2
+    django5.2: django>=5.2,<6.0


### PR DESCRIPTION
Release notes: https://docs.djangoproject.com/en/stable/releases/5.2/

All existing tests are passing, but might need a few new cases to be written (e.g. Composite Primary Keys?)